### PR TITLE
Add a link to fluentd.org in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Couchbase 2.0 plugin for Fluentd
+# Couchbase 2.0 plugin for [Fluentd](http://fluentd.org)
 
 Couchbase 2.0 output plugin for Fluentd.
 


### PR DESCRIPTION
I am adding a link to Fluentd.org in your README.md file to put Fluentd in context for newcomers.
